### PR TITLE
Only use required files in bower main array

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "openpgp",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "license": "LGPL-3.0+",
   "homepage": "http://openpgpjs.org/",
   "authors": [
@@ -9,9 +9,7 @@
   "description": "OpenPGP.js is a Javascript implementation of the OpenPGP protocol. This is defined in RFC 4880.",
   "main": [
     "dist/openpgp.js",
-    "dist/openpgp.worker.js",
-    "dist/openpgp.min.js",
-    "dist/openpgp.worker.min.js"
+    "dist/openpgp.worker.js"
   ],
   "moduleType": [
     "amd",


### PR DESCRIPTION
There was also a pull request from iDuuck at 22.02.2016. His idea was right. Just put main files to the "main" at your bower.js file.
If some guys need the minify version, they can go directly to the bower_components folder.
The main section defines only the main needed files not the minified version of the main files.
Please put the changes to your newest version :D
Thanks a lot.